### PR TITLE
feat: add option to ignore case when filtering tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,17 @@ shared_except "locked" {
     bind "Ctrl y" {
         LaunchOrFocusPlugin "file:~/.config/zellij/plugins/room.wasm" {
             floating true
+            ignore_case true
         }
     }
 }
 ```
 
 > You likely already have a `shared_except "locked"` section in your configs. Feel free to add `bind` there.
+
+
+The `ignore_case` defaults to `false` if absent. If set to `true`, filtering the tab names ignores
+the case of the filter string and the tab name.
 
 ## Contributing
 


### PR DESCRIPTION
This is a small change to add the option to ignore case when filtering tab names. 

I often have a bunch of tabs open and I'm lazy, so I'd rather not have to type out the case exactly when I'm filtering tabs!