### PR TITLE
fix(nix): disable doCheck for built artifact

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,7 @@
           name = "room";
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
+          doCheck = false;
 
           nativeBuildInputs = with pkgs; [ perl ];
 


### PR DESCRIPTION
buildRustPackage by default tries to run cargo test against the host target. zellij-tile has extern symbols that only exist in the Zellij WASM runtime, so native linking always fails.